### PR TITLE
macOS gcc-arm-embedded freeze to version 10.3-2021.10

### DIFF
--- a/macOS/gcc-arm-embedded.rb
+++ b/macOS/gcc-arm-embedded.rb
@@ -1,0 +1,53 @@
+cask "gcc-arm-embedded" do
+  # Exists as a cask because it is impractical as a formula:
+  # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
+  version "10.3-2021.10"
+  sha256 "e3888a1d0af798be7f98d67a3e6dc4fc96d92d5b57fc635e0c021a4a36087b5d"
+
+  url "https://developer.arm.com/-/media/Files/downloads/gnu-rm/#{version}/gcc-arm-none-eabi-#{version}-mac.pkg"
+  name "GCC ARM Embedded"
+  desc "Pre-built GNU bare-metal toolchain for 32-bit Arm processors"
+  homepage "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm"
+
+  livecheck do
+    url "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads"
+    regex(/href=.*?gcc-arm-none-eabi-(\d+\.\d+-\d+\.\d+)-mac.pkg/i)
+  end
+
+  pkg "gcc-arm-none-eabi-#{version}-mac.pkg"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-addr2line"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-ar"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-as"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-c++"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-c++filt"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-cpp"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-elfedit"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-g++"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-10.3.1"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-ar"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-nm"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-ranlib"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcov"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcov-dump"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcov-tool"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb-add-index"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb-add-index-py"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb-py"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gprof"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-ld"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-ld.bfd"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-lto-dump"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-nm"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-objcopy"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-objdump"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-ranlib"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-readelf"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-size"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-strings"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-strip"
+
+  uninstall pkgutil: "gcc.arm-none-eabi-#{version[/^(\d{2})/]}",
+            delete:  "/Applications/ARM"
+end

--- a/macOS/install.command
+++ b/macOS/install.command
@@ -16,7 +16,8 @@ brew update
 #brew upgrade # I don't think we should force everyone's tools to update.
 
 echo "Installing packages with Homebrew"
-brew install openocd dfu-util gcc-arm-embedded
+brew install openocd dfu-util
+brew install ./gcc-arm-embedded.rb --cask
 
 find /usr/local/Caskroom/gcc-arm-embedded -type f -perm +111 -print | xargs spctl --add --label "gcc-arm-embedded"
 find /usr/local/Caskroom/gcc-arm-embedded | xargs xattr -d com.apple.quarantine


### PR DESCRIPTION
According to some users, it seems like M1 macs have some issues with the latest macOS gcc-arm-embedded package. This PR adds a local copy of the old brew script ([which can be found here](https://github.com/Homebrew/homebrew-cask/blob/d407663b8017a0a062c7fc0b929faf2e16abd1ff/Casks/gcc-arm-embedded.rb)) and targets that for the gcc-arm-embedded install instead.

Users may need to run the uninstall.command script before running this latest version.