### PR TITLE
Absolute path to macOS files

### DIFF
--- a/macOS/install.command
+++ b/macOS/install.command
@@ -2,6 +2,7 @@
 
 # path variable
 echo "Installing DaisyToolchain"
+SCRIPTPATH=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
 
 # install brew
 if ! command -v brew &> /dev/null
@@ -11,16 +12,15 @@ then
 fi
 
 #upgrade homebrew
-echo "Upgrading Homebrew"
+echo "Updating Homebrew"
 brew update
 #brew upgrade # I don't think we should force everyone's tools to update.
 
 echo "Installing packages with Homebrew"
 brew install openocd dfu-util
-brew install ./gcc-arm-embedded.rb --cask
+brew install $SCRIPTPATH/gcc-arm-embedded.rb --cask
 
 find /usr/local/Caskroom/gcc-arm-embedded -type f -perm +111 -print | xargs spctl --add --label "gcc-arm-embedded"
 find /usr/local/Caskroom/gcc-arm-embedded | xargs xattr -d com.apple.quarantine
 
 echo "Done"
-


### PR DESCRIPTION
This PR changes the relative `./gcc-arm-embedded.rb` path to an absolute one, meaning the script can be run from anywhere (#19). I tested the script from a subdirectory, an arbitrarily distant directory, and the root directory with good results. The full install still produced a working toolchain on my machine as well.