### PR TITLE
Few fixes for macOS install script

### DIFF
--- a/macOS/gcc-arm-embedded-10.rb
+++ b/macOS/gcc-arm-embedded-10.rb
@@ -1,4 +1,4 @@
-cask "gcc-arm-embedded" do
+cask "gcc-arm-embedded-10" do
   # Exists as a cask because it is impractical as a formula:
   # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
   version "10.3-2021.10"

--- a/macOS/install.command
+++ b/macOS/install.command
@@ -2,11 +2,10 @@
 
 # path variable
 echo "Installing DaisyToolchain"
-SCRIPTPATH=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
+SCRIPTPATH=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # install brew
-if ! command -v brew &> /dev/null
-then
+if ! command -v brew &> /dev/null; then
     echo "Installing Homebrew: Follow onscreen instructions"
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
@@ -18,9 +17,9 @@ brew update
 
 echo "Installing packages with Homebrew"
 brew install openocd dfu-util
-brew install $SCRIPTPATH/gcc-arm-embedded.rb --cask
+brew install "$SCRIPTPATH"/gcc-arm-embedded-10.rb --cask
 
-find /usr/local/Caskroom/gcc-arm-embedded -type f -perm +111 -print | xargs spctl --add --label "gcc-arm-embedded"
-find /usr/local/Caskroom/gcc-arm-embedded | xargs xattr -d com.apple.quarantine
+find /Applications/ARM/bin -type f -perm +111 -print0 | xargs spctl --add --label "gcc-arm-embedded-10"
+find /Applications/ARM/bin -print0 | xargs xattr -d com.apple.quarantine
 
 echo "Done"


### PR DESCRIPTION
minor fixes for the shell script
cask renamed to prevent auto upgrade
gcc-arm-embedded now installs to /Applications/ARM/bin